### PR TITLE
Colorpickers didn't get removed from DOM after element destroy

### DIFF
--- a/js/color-picker.js
+++ b/js/color-picker.js
@@ -470,7 +470,7 @@ colorPicker.directive('colorPicker', ['$document', '$compile', 'ColorHelper', fu
                     element.off('click', open);
                     element.off('keyup', keyup);
                     element.off('paste', delayedUpdate);
-					template.remove();
+                    template.remove();
                 });
 
                 function mousedown(event) {

--- a/js/color-picker.js
+++ b/js/color-picker.js
@@ -470,6 +470,7 @@ colorPicker.directive('colorPicker', ['$document', '$compile', 'ColorHelper', fu
                     element.off('click', open);
                     element.off('keyup', keyup);
                     element.off('paste', delayedUpdate);
+					template.remove();
                 });
 
                 function mousedown(event) {


### PR DESCRIPTION
After the element calling the directive got destroyed the colorpicker is still attached to the body of the DOM